### PR TITLE
Corrected typos and wrong translations. Missing translations added.

### DIFF
--- a/locale/de/settings.cfg
+++ b/locale/de/settings.cfg
@@ -1,47 +1,57 @@
 [helmod_settings]
-debug=Debug Modus
-debug-desc=Benutze den Debugmodus nicht während des Spiels, es verringert die Skriptausführungsgeschwundigkeit
+debug=Debugmodus
+debug-desc=Benutze den Debugmodus nicht während des Spiels, er verringert die Spielgeschwindigkeit
 
-debug-filter=Debug Modus Class Filter
-debug-filter-desc=Benutze den Debugmodus nicht während des Spiels, es verringert die Skriptausführungsgeschwundigkeit
+debug-filter=Debugmodus Klassenfilter
+debug-filter-desc=Benutze den Debugmodus nicht während des Spiels, er verringert die Spielgeschwindigkeit
 
-format-number-factory=Factory Nummer Format
+format-number-factory=Montagemaschinennummer-Format
 format-number-factory-desc=
 
-format-number-element=Element Nummer Formar
+format-number-element=Elementnummer-Format
 format-number-element-desc=Ein Element ist ein Produkt oder eine Zutat
 
-display-size=Anzeigegröße
-display-size-desc=Dies ermöglicht die genaue Auflösungseinstellung, die aber nur beachtet wird wenn der Parameter "Freie Bildschirmgröße" leer oder aktiviert ist
+display-size=Bildschirmauflösung
+display-size-desc=Die Größe des helmod-Fensters wird hieraus berechnet. Wird ignoriert wenn bei "Benutzerdefinierte Bildschirmauflösung" etwas eingetragen ist.
 
-display-size-free=Freie Bildschirmgröße
-display-size-free-desc=Es ist dir freigestellt die Auflösung einzutragen im folgendem Format:1920x1080
+display-size-free=Benutzerdefinierte Bildschirmauflösung
+display-size-free-desc=Um die Größe des helmod-Fensters genauer anzupassen. Erwartetes Eingabeformat: <Breite>x<Höhe> (Bsp.: 1280x1024)
 
-display-location=Ort der Hauptauswahl
-display-location-desc=Entscheide wo die Hauptauswahl erscheint
+display-location=Anzeigeposition
+display-location-desc=Bestimme wo das helmod-Fenster erscheint
 
-display-product-cols=Produktspalte anzeigen
+display-product-cols=Angezeigte Produktspalten
 
-display-ingredient-cols=Zutatenaplte anzeigen
+display-ingredient-cols=Angezeigte Zutatenspalten
 
-display-cell-mod=Anzeige im "Zell-Modus"
+display-cell-mod=Art der Zellenanzeige
 
-display-real-name=Richtiger name
+display-real-name=Richtiger Name
 
-display-data-col-index=Die Indexspalte anzeigen
+display-data-col-index=Indexspalte zeigen
 
-display-data-col-id=ID Spalte anzeigen
+display-data-col-id=ID-Spaltenzeigen
 
-display-data-col-name=Namenspalte anzeigen
+display-data-col-name=Namenspalte zeigen
 
-model-filter-factory=Model Filter einstellen
+model-filter-factory=Modelfilter aktivieren
+model-filter-factory-desc=Nur verfügbare Produktionsgebäude werden angezeigt
 
-model-filter-beacon=Effektübertragungsmodulfilter einstellen
+model-filter-beacon=Effektübertragungsmodulfilter aktivieren
 
-model-filter-factory-module=Filtern nach Modulen der Factory
+model-filter-factory-module=Filtern nach Modulen in Montagemaschinen
+
 model-filter-beacon-module=Filtern nach Modulen in Effektübertragungsgeräten
 
-model-filter-generator=Filter auf Generatoren einstellen
+model-filter-generator=Filter auf Generatoren aktivieren
 
-properties-tab=Display properties tab
-properties-tab-desc=Display of the properties of a factorio object
+properties-tab=Zeige Voraussetzungen-Tab
+properties-tab-desc=Zeigt das Voraussetzungen-Tab oben im helmod-Hauptfenster
+
+row-move-step=Schritte beim Verschieben einer Zeile
+
+default-factory-level=Standardlevel der Montagemaschinen
+default-factory-level-desc=Stellt die Stufe der Montagemaschine ein, die einem neuen Rezept zugeordnet wird. 1 ist die langsamste Montagemaschinen, "last" die schnellste.
+
+filter-on-text-changed=Beim Texteintippen filtern
+filter-on-text-changed-desc=Wenn aktiviert wird direkt beim Eintippen gesucht, sonst erst beim Klicken auf den Anwenden-Button.

--- a/locale/de/settings.cfg
+++ b/locale/de/settings.cfg
@@ -1,8 +1,8 @@
 [helmod_settings]
-debug=Debugmodus
+debug=Debugmodus aktivieren
 debug-desc=Benutze den Debugmodus nicht während des Spiels, er verringert die Spielgeschwindigkeit
 
-debug-filter=Debugmodus Klassenfilter
+debug-filter=Debugmodus des Klassenfilters aktivieren
 debug-filter-desc=Benutze den Debugmodus nicht während des Spiels, er verringert die Spielgeschwindigkeit
 
 format-number-factory=Montagemaschinennummer-Format
@@ -20,9 +20,9 @@ display-size-free-desc=Um die Größe des helmod-Fensters genauer anzupassen. Er
 display-location=Anzeigeposition
 display-location-desc=Bestimme wo das helmod-Fenster erscheint
 
-display-product-cols=Angezeigte Produktspalten
+display-product-cols=Breite der Produktspalten anpassen
 
-display-ingredient-cols=Angezeigte Zutatenspalten
+display-ingredient-cols=Breite der Zutatenspalten anpassen
 
 display-cell-mod=Art der Zellenanzeige
 
@@ -30,7 +30,7 @@ display-real-name=Richtiger Name
 
 display-data-col-index=Indexspalte zeigen
 
-display-data-col-id=ID-Spaltenzeigen
+display-data-col-id=ID-Spalten zeigen
 
 display-data-col-name=Namenspalte zeigen
 
@@ -48,7 +48,7 @@ model-filter-generator=Filter auf Generatoren aktivieren
 properties-tab=Zeige Voraussetzungen-Tab
 properties-tab-desc=Zeigt das Voraussetzungen-Tab oben im helmod-Hauptfenster
 
-row-move-step=Schritte beim Verschieben einer Zeile
+row-move-step=Verschiebt die Spalten einer Rezeptzeile minimal
 
 default-factory-level=Standardlevel der Montagemaschinen
 default-factory-level-desc=Stellt die Stufe der Montagemaschine ein, die einem neuen Rezept zugeordnet wird. 1 ist die langsamste Montagemaschinen, "last" die schnellste.


### PR DESCRIPTION
I corrected a lot of typos and several wrong translations / usage of false friends. Added several translations that were simply missing to date.

Still no idea what "Product column base", "Ingredient column base", and "Step of moving a row" means.