### PR TITLE
Changed getElectricEffectivity() to return nothing.

### DIFF
--- a/model/EntityPrototype.lua
+++ b/model/EntityPrototype.lua
@@ -392,9 +392,6 @@ end
 -- @return #number default 0
 --
 function EntityPrototype.getElectricEffectivity()
-  if lua_entity_prototype ~= nil and lua_entity_prototype.electric_energy_source_prototype ~= nil then
-    return lua_entity_prototype.electric_energy_source_prototype.effectivity or 0
-  end
   return 0
 end
 


### PR DESCRIPTION
Fixes #130 

Upstream removed the ` LuaElectricEnergySourcePrototype::effectivity` attribute.

This may be a naive fix, but without examining the full usage of the function throughout the code, this is the easy path.
