### PR TITLE
Fixed a precision of Format.round

### DIFF
--- a/core/Format.lua
+++ b/core/Format.lua
@@ -44,12 +44,14 @@ end
 -- @return #number the formated number
 --
 function Format.round(val, decimal)
-  if (decimal) then
-    return math.ceil( (val * 10^decimal)) / (10^decimal)
+  if decimal then
+    local exponent = 10 ^ decimal
+    return math.floor(val * exponent + 0.5) / exponent
   else
-    return math.ceil(val)
+    return math.floor(val + 0.5)
   end
 end
+
 -------------------------------------------------------------------------------
 -- Format the number
 --


### PR DESCRIPTION
There is an issue when ```addCellFactory``` function calls ```Format.formatNumberFactory(factory.count)```
Sometimes ```factory.count``` is incorrectly rounded due to precision errors of floating-point numbers.

For instance, "factory number" = 1:
![text](https://i.imgur.com/6lTUfNZ.png)

I can't get an actual value of ```factory.count``` I think the value looks like 1.00000000007
Also the factory cell displays 2 when a factory number format is "0".

My pull request fixed the issue.