### PR TITLE
Fixed getElementAmount for products with amount and probability

### DIFF
--- a/model/Product.lua
+++ b/model/Product.lua
@@ -100,7 +100,11 @@ function Product.getElementAmount(element)
   if element == nil then return 0 end
 
   if element.amount ~= nil then
-    return element.amount
+    if element.probability ~= nil then
+      return element.amount * element.probability
+    else
+      return element.amount
+    end
   end
 
   if element.probability ~= nil and element.amount_min ~= nil and  element.amount_max ~= nil then


### PR DESCRIPTION
This is a fix for #196 

I had the same problem in SeaBlock when trying to calculate geode processing. It seems like the "Washing for geodes" recipe has amount and probability but not amount_min and amount_max. 