### PR TITLE
Handle 0.17 probabilities

### DIFF
--- a/model/Product.lua
+++ b/model/Product.lua
@@ -100,7 +100,13 @@ function Product.getElementAmount(element)
   if element == nil then return 0 end
 
   if element.amount ~= nil then
-    return element.amount
+    -- In 0.17, it seems probability can be used with just 'amount' and it
+    -- doesn't need to use amount_min/amount_max
+    if element.probability ~= nil then
+      return element.amount * element.probability
+    else
+      return element.amount
+    end
   end
 
   if element.probability ~= nil and element.amount_min ~= nil and  element.amount_max ~= nil then


### PR DESCRIPTION
It seems that in 0.17 probabilities can be associated with "amount" and not just "amount_min" and "amount_max". (see issue #202).

This is a small patch that seems to solve the issue for me. I'm happy to discuss different fixes for this, but I figured I'd put up code rather than just a complaint.
