### PR TITLE
Fix fuel selection in recipe

### DIFF
--- a/edition/RecipeEdition.lua
+++ b/edition/RecipeEdition.lua
@@ -731,8 +731,8 @@ function RecipeEdition:updateFactoryInfo(event)
           fuel_list = {factory_fuel:native()}
         end
       else
-        local fuel_list = energy_prototype:getFuelPrototypes()
-        local factory_fuel = energy_prototype:getFuelPrototype()
+        fuel_list = energy_prototype:getFuelPrototypes()
+        factory_fuel = energy_prototype:getFuelPrototype()
       end
       
       if factory_fuel ~= nil then


### PR DESCRIPTION
https://github.com/Helfima/helmod/commit/85cdcc6beb3a6ccd8134fa7a5a7b731dbdb6dbd7#diff-5957b9d8fdd058937100865fe43affccR734 broke the fuel selection in recipe

This is because the `local` keyword was used, meaning it would create a new local variable; not updating the fuel list of the method.

Tested locally