### PR TITLE
Fixes a grammer error

### DIFF
--- a/data/ModelCompute.lua
+++ b/data/ModelCompute.lua
@@ -675,7 +675,7 @@ function ModelCompute.computeBlock(block)
         mC, runtimes = my_solver:solve(mA, debug, block.by_factory, time)
       end)
       if not(ok) then
-        Player.print("Matrix solver can not found solution!")
+        Player.print("Matrix solver can not find solution!")
       end
 
       if User.getModGlobalSetting("debug_solver") == true then


### PR DESCRIPTION
Minor thing in the grand scheme of things but I had my browser open on my second monitor so why not fix it

`Matrix solver can not found solution!` => `Matrix solver can not find solution!`