### PR TITLE
Fixed issue with fluid temperatures in ProductEdition

### DIFF
--- a/data/ModelBuilder.lua
+++ b/data/ModelBuilder.lua
@@ -827,8 +827,16 @@ function ModelBuilder.updateProduct(block, product_name, quantity)
     if block.by_product == false then
       block_elements = block.ingredients
     end
-    if block_elements ~= nil and block_elements[product_name] ~= nil then
-      block_elements[product_name].input = quantity
+    if block_elements ~= nil then
+      if block_elements[product_name] ~= nil then
+        block_elements[product_name].input = quantity
+      else
+        for key, value in pairs(block_elements) do
+          if value.name == product_name then
+            value.input = quantity
+          end
+        end
+      end
     end
   end
 end

--- a/edition/ProductEdition.lua
+++ b/edition/ProductEdition.lua
@@ -82,8 +82,17 @@ function ProductEdition:onUpdate(event)
       block_elements = block.ingredients
     end
     local element_name = event.item4
-    if block_elements ~= nil and block_elements[element_name] ~= nil then
-      product = block_elements[element_name]
+    if block_elements ~= nil then
+      if block_elements[element_name] ~= nil then
+        product = block_elements[element_name]
+      else
+        -- Maybe product key contains temperature (ex. "steam#165")
+        for key, value in pairs(block_elements) do
+          if value.name == element_name then
+            product = value
+          end
+        end
+      end
       product_count = product.input or 0
     end
   end


### PR DESCRIPTION
 - Could not set the quantity of a product that is a fluid with
temperature due to the key in the block.products table being
different then the name of the product.
- Once set the quantity would not be updated due to the same issue.

Before:
![HelmodBug3](https://user-images.githubusercontent.com/305423/116339341-42639200-a7ab-11eb-9ae9-39049af6a5b6.png)

After:
![HelmodBugFixed](https://user-images.githubusercontent.com/305423/116339537-98d0d080-a7ab-11eb-8d77-26e067c77f46.png)
