### PR TITLE
Fix escape key opening factorio menu

### DIFF
--- a/core/Form.lua
+++ b/core/Form.lua
@@ -335,6 +335,7 @@ function Form:open(event)
 
   if self.classname == "HMProductionPanel" then
     Player.setShortcutState(true)
+    Player.native().opened = self:getPanel()
   end
 
   return true


### PR DESCRIPTION
Pressing the escape key will no longer open the factorio escape menu when helmod is open, instead it will simply close helmod.