### PR TITLE
Fix misspelling of "report"

### DIFF
--- a/locale/en/helmod.cfg
+++ b/locale/en/helmod.cfg
@@ -518,7 +518,7 @@ pollution-module-low=Limitation pollution because value cannot be reduce more th
 helmod=Helmod
 
 [helmod_bug-repport-panel]
-title=Bug Repport
+title=Bug Report
 no_error=No errors to report
 
 [helmod_limitation]


### PR DESCRIPTION
Also adds a newline at the end of file because of the web editor.